### PR TITLE
Set preferred content size of RichTextViewController after text container layout has completed

### DIFF
--- a/Sources/RichTextRenderer/ViewController/RichTextViewController.swift
+++ b/Sources/RichTextRenderer/ViewController/RichTextViewController.swift
@@ -140,6 +140,15 @@ open class RichTextViewController: UIViewController, NSLayoutManagerDelegate {
         }
     }
 
+    private func calculateAndSetPreferredContentSize() {
+        let newContentSize = textView.sizeThatFits(textView.bounds.size)
+        guard newContentSize != preferredContentSize else {
+            return
+        }
+
+        preferredContentSize = newContentSize
+    }
+
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         // Expect text view to be of the passed in `size`.
         expectedTextViewSizeAfterOrientationChange = size
@@ -179,6 +188,8 @@ open class RichTextViewController: UIViewController, NSLayoutManagerDelegate {
                 layoutHorizontalRuleElement(attributes: attributes, range: range, containerSize: containerSize)
             }
         }
+
+        calculatePreferredContentSize()
     }
 
     private func layoutEmbedElement(attributes: [NSAttributedString.Key: Any], range: NSRange, containerSize: CGSize) {


### PR DESCRIPTION
### Goal
Whenever the layout and the size of the text view within the RichTextViewController changes, we want to set the preferred content size of the RichTextViewController to reflect the content size fo the the text view. This allows us to determine the size of the view's content to be used in scenarios where we use the RichTextViewController as a child view of another container view controller.

### Details
This solution was inspired by [this article](https://useyourloaf.com/blog/self-sizing-child-views/). As the article explains, setting the `preferredContentSize` on a child controller triggers the `preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer)` method in the parent. This way we get notified of any size change and the size new itself, allowing us to adjust the size of the view displaying the contents of the RichTextViewController accordingly.

### Why child view controllers in the context of Contentful?
We ran into the scenario where we need to to use RichTextViewController as a child view controller because our content model is not defied by just one rich text field, but rather a combination of a rich text field that defines the body and other text fields that define the title and other information about the content. This leads to a situation where we cannot simply use the RichTextViewController as is to display the entirety of the content in the manner we want to.